### PR TITLE
Replace 'unicode' with 'six.text_type'

### DIFF
--- a/ansible-adaptor/swagger_server/util.py
+++ b/ansible-adaptor/swagger_server/util.py
@@ -1,6 +1,6 @@
 from typing import GenericMeta
 from datetime import datetime, date
-from six import integer_types, iteritems
+from six import integer_types, iteritems, text_type
 
 
 def _deserialize(data, klass):
@@ -45,7 +45,7 @@ def _deserialize_primitive(data, klass):
     try:
         value = klass(data)
     except UnicodeEncodeError:
-        value = unicode(data)
+        value = text_type(data)
     except TypeError:
         value = data
     return value


### PR DESCRIPTION
__unicode__ is an undefined name in Python 3 which could raise a NameError at runtime.

flake8 testing of https://github.com/IBM/osslm-ansible-resource-manager on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./ansible-adaptor/swagger_server/util.py:48:17: F821 undefined name 'unicode'
        value = unicode(data)
                ^
1     F821 undefined name 'unicode'
1
```