### PR TITLE
Logging Changes to support LM, Helm Chart

### DIFF
--- a/alm-ansible-rm-docker-compose.yml
+++ b/alm-ansible-rm-docker-compose.yml
@@ -13,7 +13,7 @@ services:
        - "9042:9042"
        - "9160:9160"
      volumes:
-       - "./var_alm_ansible_rm/cassandra:/var/lib/cassandra/data"
+       - "cassandradata1:/var/lib/cassandra/data"
      environment:
        # important: broadcast address must be set to the Docker hostname
        - CASSANDRA_BROADCAST_ADDRESS=alm-ansible-rm-db
@@ -21,22 +21,25 @@ services:
        - CASSANDRA_SEEDS=alm-ansible-rm-db
        - CASSANDRA_REMOTE_CONNECTION=true
        - CASSANDRA_START_RPC=true
-  alm-ansible-rm:
-     hostname: ansible-rm
-     container_name: ansible-rm
-     build:
-       context: ./ansible-adaptor
-       dockerfile: Dockerfile
-     ports:
-       - "8080:8080"
-     volumes:
-       - "./var_alm_ansible_rm/driver:/var/alm_ansible_rm"
-       - "./ansible-adaptor:/usr/src/app"
-     environment:
-       - LOG_LEVEL=DEBUG
-       - LOG_FOLDER=/var/alm_ansible_rm/logs
-       - OS_CLIENT_CONFIG_FILE=/var/alm_ansible_rm/clouds/clouds.yaml
-     extra_hosts:
-       - "kafka:192.168.61.64"
-     depends_on:
-       - alm-ansible-rm-db
+#  alm-ansible-rm:
+#     hostname: ansible-rm
+#     container_name: ansible-rm
+#     build:
+#       context: ./ansible-adaptor
+#       dockerfile: Dockerfile
+#     ports:
+#       - "8080:8080"
+#     volumes:
+#       - "./var_alm_ansible_rm/driver:/var/alm_ansible_rm"
+#       - "./ansible-adaptor:/usr/src/app"
+#     environment:
+#       - LOG_LEVEL=DEBUG
+#       - LOG_FOLDER=/var/alm_ansible_rm/logs
+#       - OS_CLIENT_CONFIG_FILE=/var/alm_ansible_rm/clouds/clouds.yaml
+#     extra_hosts:
+#       - "kafka:192.168.61.64"
+#     depends_on:
+#       - alm-ansible-rm-db
+volumes:
+  cassandradata1:
+    driver: local

--- a/alm-ansible-rm-docker-compose.yml
+++ b/alm-ansible-rm-docker-compose.yml
@@ -13,7 +13,7 @@ services:
        - "9042:9042"
        - "9160:9160"
      volumes:
-       - "cassandradata1:/var/lib/cassandra/data"
+       - "./var_alm_ansible_rm/cassandra:/var/lib/cassandra/data"
      environment:
        # important: broadcast address must be set to the Docker hostname
        - CASSANDRA_BROADCAST_ADDRESS=alm-ansible-rm-db
@@ -21,25 +21,22 @@ services:
        - CASSANDRA_SEEDS=alm-ansible-rm-db
        - CASSANDRA_REMOTE_CONNECTION=true
        - CASSANDRA_START_RPC=true
-#  alm-ansible-rm:
-#     hostname: ansible-rm
-#     container_name: ansible-rm
-#     build:
-#       context: ./ansible-adaptor
-#       dockerfile: Dockerfile
-#     ports:
-#       - "8080:8080"
-#     volumes:
-#       - "./var_alm_ansible_rm/driver:/var/alm_ansible_rm"
-#       - "./ansible-adaptor:/usr/src/app"
-#     environment:
-#       - LOG_LEVEL=DEBUG
-#       - LOG_FOLDER=/var/alm_ansible_rm/logs
-#       - OS_CLIENT_CONFIG_FILE=/var/alm_ansible_rm/clouds/clouds.yaml
-#     extra_hosts:
-#       - "kafka:192.168.61.64"
-#     depends_on:
-#       - alm-ansible-rm-db
-volumes:
-  cassandradata1:
-    driver: local
+  alm-ansible-rm:
+     hostname: ansible-rm
+     container_name: ansible-rm
+     build:
+       context: ./ansible-adaptor
+       dockerfile: Dockerfile
+     ports:
+       - "8080:8080"
+     volumes:
+       - "./var_alm_ansible_rm/driver:/var/alm_ansible_rm"
+       - "./ansible-adaptor:/usr/src/app"
+     environment:
+       - LOG_LEVEL=DEBUG
+       - LOG_FOLDER=/var/alm_ansible_rm/logs
+       - OS_CLIENT_CONFIG_FILE=/var/alm_ansible_rm/clouds/clouds.yaml
+     extra_hosts:
+       - "kafka:192.168.61.64"
+     depends_on:
+       - alm-ansible-rm-db

--- a/ansible-adaptor/config.yml
+++ b/ansible-adaptor/config.yml
@@ -8,8 +8,15 @@ driver:
   properties:
     - responseKafkaConnectionUrl: "kafka:9092"
     - responseKafkaTopicName: "ansible-rm"
+logging:
+  type: text
+#  type: logstash
 ansible:
   resource_dir: "/var/alm_ansible_rm/resources"
   keys_dir: "/var/alm_ansible_rm/keys"
+#  resource_dir: "/Users/stevenglover/src/osslm-ansible-resource-manager/var_alm_ansible_rm/driver/resources"
+#  keys_dir: "/Users/stevenglover/src/osslm-ansible-resource-manager/var_alm_ansible_rm/driver/keys"
 cassandra:
+#  uri: alm-ansible-rm-db
+  uri: 192.168.99.100
   ttl: 86400

--- a/ansible-adaptor/config.yml
+++ b/ansible-adaptor/config.yml
@@ -8,15 +8,10 @@ driver:
   properties:
     - responseKafkaConnectionUrl: "kafka:9092"
     - responseKafkaTopicName: "ansible-rm"
-logging:
-  type: text
-#  type: logstash
 ansible:
   resource_dir: "/var/alm_ansible_rm/resources"
   keys_dir: "/var/alm_ansible_rm/keys"
-#  resource_dir: "/Users/stevenglover/src/osslm-ansible-resource-manager/var_alm_ansible_rm/driver/resources"
-#  keys_dir: "/Users/stevenglover/src/osslm-ansible-resource-manager/var_alm_ansible_rm/driver/keys"
 cassandra:
-#  uri: alm-ansible-rm-db
-  uri: 192.168.99.100
+  uri: alm-ansible-rm-db
+#  uri: 192.168.99.100
   ttl: 86400

--- a/ansible-adaptor/config.yml
+++ b/ansible-adaptor/config.yml
@@ -13,5 +13,4 @@ ansible:
   keys_dir: "/var/alm_ansible_rm/keys"
 cassandra:
   uri: alm-ansible-rm-db
-#  uri: 192.168.99.100
   ttl: 86400

--- a/ansible-adaptor/swagger_server/__main__.py
+++ b/ansible-adaptor/swagger_server/__main__.py
@@ -28,11 +28,12 @@ if __name__ == '__main__':
 
     log_type = os.environ.get('LOG_TYPE')
     if log_type is None:
+        # "flat" is the default, nothing specific to configure for this
         log_type = 'flat'
 
-    # set Logstash formatter for all logging handlers
     if(log_type == 'logstash'):
         formatter = LogstashFormatterVersion1('logstash')
+        # set Logstash formatter for all logging handlers
         [handler.setFormatter(formatter) for handler in app.app.logger.handlers]
 
     # set socket to send logs to

--- a/ansible-adaptor/swagger_server/__main__.py
+++ b/ansible-adaptor/swagger_server/__main__.py
@@ -26,6 +26,15 @@ if __name__ == '__main__':
     if log_level is None:
         log_level = 'INFO'
 
+    log_type = os.environ.get('LOG_TYPE')
+    if log_type is None:
+        log_type = 'flat'
+
+    # set Logstash formatter for all logging handlers
+    if(log_type == 'logstash'):
+        formatter = LogstashFormatterVersion1('logstash')
+        [handler.setFormatter(formatter) for handler in app.app.logger.handlers]
+
     # set socket to send logs to
     # this is to allow multiple processes logging
     socketHandler = logging.handlers.SocketHandler('localhost',
@@ -38,11 +47,6 @@ if __name__ == '__main__':
     #copy required resources
     with app.app.app_context():
         config = ConfigReader()
-
-        # set Logstash formatter for all logging handlers
-        if(config.logging_type == 'logstash'):
-            formatter = LogstashFormatterVersion1('logstash')
-            [handler.setFormatter(formatter) for handler in app.app.logger.handlers]
 
         resource_dir = config.getResourceDir()
         src_dir = dirname(dirname(abspath(__file__)))

--- a/ansible-adaptor/swagger_server/controllers/ans_cassandra.py
+++ b/ansible-adaptor/swagger_server/controllers/ans_cassandra.py
@@ -7,7 +7,7 @@ IBM Corporation, 2017, jochen kappel
 from flask import current_app as app
 from cassandra.cluster import Cluster
 from cassandra.query import dict_factory
-
+from .ans_driver_config import ConfigReader
 
 class CassandraHandler:
     """
@@ -17,6 +17,7 @@ class CassandraHandler:
         """ inner signelton class"""
         def __init__(self):
             self.keyspace = "alm_ansible"
+            self.config = ConfigReader()
             self.dbSession = None
 
         def __del__(self):
@@ -30,7 +31,7 @@ class CassandraHandler:
                 app.logger.info('creating cassandra session ' + self.keyspace)
 
                 try:
-                    self.cluster = Cluster(['alm-ansible-rm-db'])
+                    self.cluster = Cluster([self.config.cassandra_uri])
 
                     self.dbSession = self.cluster.connect()
                     app.logger.info('connected to cassandra, keyspace: ' + self.keyspace)

--- a/ansible-adaptor/swagger_server/controllers/ans_driver_config.py
+++ b/ansible-adaptor/swagger_server/controllers/ans_driver_config.py
@@ -27,6 +27,8 @@ class ConfigReader:
             self.driver_name = cfg['driver']['name']
             self.driver_version = cfg['driver']['version']
             self.requests_ttl = cfg['cassandra']['ttl']
+            self.cassandra_uri = cfg['cassandra']['uri']
+            self.logging_type = cfg['logging']['type']
 
             self.resource_dir = cfg['ansible']['resource_dir']
             app.logger.debug('check for resource folder: ' + self.resource_dir)

--- a/ansible-adaptor/swagger_server/controllers/ans_driver_config.py
+++ b/ansible-adaptor/swagger_server/controllers/ans_driver_config.py
@@ -26,11 +26,10 @@ class ConfigReader:
             app.logger.info('loading configuration')
             self.driver_name = cfg['driver']['name']
             self.driver_version = cfg['driver']['version']
-            self.requests_ttl = cfg['cassandra']['ttl']
-            self.cassandra_uri = cfg['cassandra']['uri']
-            self.logging_type = cfg['logging']['type']
+            self.requests_ttl = os.environ.get('cassandra_ttl', None) or cfg['cassandra']['ttl']
+            self.cassandra_uri = os.environ.get('cassandra_uri', None) or cfg['cassandra']['uri']
 
-            self.resource_dir = cfg['ansible']['resource_dir']
+            self.resource_dir = os.environ.get('ansible_resource_dir', None) or cfg['ansible']['resource_dir']
             app.logger.debug('check for resource folder: ' + self.resource_dir)
             # check if configured directory exists:
             if not os.path.isdir(self.resource_dir):
@@ -38,7 +37,7 @@ class ConfigReader:
                 app.logger.info('creating resource folder ' + self.resource_dir)
                 os.mkdir(self.resource_dir)
 
-            self.keys_dir = cfg['ansible']['keys_dir']
+            self.keys_dir = os.environ.get('ansible_keys_dir', None) or cfg['ansible']['keys_dir']
             app.logger.debug('check for keys folder: ' + self.keys_dir)
             # check if configured directory exists:
             if not os.path.isdir(self.keys_dir):

--- a/ansible-adaptor/swagger_server/controllers/ans_logging.py
+++ b/ansible-adaptor/swagger_server/controllers/ans_logging.py
@@ -1,0 +1,157 @@
+import logging
+import threading
+import uuid
+import traceback
+import logging
+import socket
+import sys
+from datetime import datetime
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
+threadLocal = threading.local()
+
+class LogstashFormatterBase(logging.Formatter):
+
+    def __init__(self, message_type='Logstash', tags=None, fqdn=False):
+        self.message_type = message_type
+        self.tags = tags if tags is not None else []
+
+        if fqdn:
+            self.host = socket.getfqdn()
+        else:
+            self.host = socket.gethostname()
+
+    def get_extra_fields(self, record):
+        # The list contains all the attributes listed in
+        # http://docs.python.org/library/logging.html#logrecord-attributes
+        skip_list = (
+            'args', 'asctime', 'created', 'exc_info', 'exc_text', 'filename',
+            'funcName', 'id', 'levelname', 'levelno', 'lineno', 'module',
+            'msecs', 'msecs', 'message', 'msg', 'name', 'pathname', 'process',
+            'processName', 'relativeCreated', 'thread', 'threadName', 'extra')
+
+#        if sys.version_info < (3, 0):
+#            easy_types = (basestring, bool, dict, float, int, long, list, type(None))
+#        else:
+        easy_types = (str, bool, dict, float, int, list, type(None))
+
+        fields = {}
+
+        for key, value in record.__dict__.items():
+            if key not in skip_list:
+                if isinstance(value, easy_types):
+                    fields[key] = value
+                else:
+                    fields[key] = repr(value)
+
+        return fields
+
+    def get_debug_fields(self, record):
+        fields = {
+            'stack_trace': self.format_exception(record.exc_info),
+            'lineno': record.lineno,
+            'process': record.process,
+            'thread_name': record.threadName,
+        }
+
+        # funcName was added in 2.5
+        if not getattr(record, 'funcName', None):
+            fields['funcName'] = record.funcName
+
+        # processName was added in 2.6
+        if not getattr(record, 'processName', None):
+            fields['processName'] = record.processName
+
+        return fields
+
+    @classmethod
+    def format_source(cls, message_type, host, path):
+        return "%s://%s/%s" % (message_type, host, path)
+
+    @classmethod
+    def format_timestamp(cls, time):
+        tstamp = datetime.utcfromtimestamp(time)
+        return tstamp.strftime("%Y-%m-%dT%H:%M:%S") + ".%03d" % (tstamp.microsecond / 1000) + "Z"
+
+    @classmethod
+    def format_exception(cls, exc_info):
+        return ''.join(traceback.format_exception(*exc_info)) if exc_info else ''
+
+    @classmethod
+    def serialize(cls, message):
+#        if sys.version_info < (3, 0):
+#            return json.dumps(message)
+#        else:
+        return json.dumps(message)
+
+class LogstashFormatterVersion0(LogstashFormatterBase):
+    version = 0
+
+    def format(self, record):
+        txnId = getattr(threadLocal, 'txnId', None)
+        if(txnId is None):
+            txnId = uuid.uuid4()
+            threadLocal.txnId = txnId
+
+        # Create message dict
+        message = {
+            '@timestamp': self.format_timestamp(record.created),
+            '@message': record.getMessage(),
+            '@source': self.format_source(self.message_type, self.host,
+                                          record.pathname),
+            '@source_host': self.host,
+            '@source_path': record.pathname,
+            '@tags': self.tags,
+            '@type': self.message_type,
+            '@fields': {
+                'levelname': record.levelname,
+                'logger': record.name,
+            },
+            '@tracectx.transactionid': str(txnId)
+        }
+
+        # Add extra fields
+        message['@fields'].update(self.get_extra_fields(record))
+
+        # If exception, add debug info
+        if record.exc_info:
+            message['@fields'].update(self.get_debug_fields(record))
+
+        return self.serialize(message)
+
+
+class LogstashFormatterVersion1(LogstashFormatterBase):
+
+    def format(self, record):
+        txnId = getattr(threadLocal, 'txnId', None)
+        if(txnId is None):
+            txnId = uuid.uuid4()
+            threadLocal.txnId = txnId
+
+        # Create message dict
+        message = {
+            '@timestamp': self.format_timestamp(record.created),
+            '@version': '1',
+            'message': record.getMessage(),
+            'host': self.host,
+            'path': record.pathname,
+            'tags': self.tags,
+            'type': self.message_type,
+
+            # Extra Fields
+            'level': record.levelname,
+            'logger_name': record.name,
+            '@tracectx.transactionid': str(txnId)
+        }
+
+        # Add extra fields
+        message.update(self.get_extra_fields(record))
+
+        # If exception, add debug info
+        if record.exc_info:
+            message.update(self.get_debug_fields(record))
+
+        return self.serialize(message)

--- a/ansible-adaptor/swagger_server/controllers/ans_logging.py
+++ b/ansible-adaptor/swagger_server/controllers/ans_logging.py
@@ -87,44 +87,6 @@ class LogstashFormatterBase(logging.Formatter):
 #        else:
         return json.dumps(message)
 
-class LogstashFormatterVersion0(LogstashFormatterBase):
-    version = 0
-
-    def format(self, record):
-        txnId = getattr(threadLocal, 'txnId', None)
-        if(txnId is None):
-            txnId = uuid.uuid4()
-            threadLocal.txnId = txnId
-
-        # Create message dict
-        message = {
-            '@timestamp': self.format_timestamp(record.created),
-            '@message': record.getMessage(),
-            '@source': self.format_source(self.message_type, self.host,
-                                          record.pathname),
-            '@source_host': self.host,
-            '@source_path': record.pathname,
-            '@tags': self.tags,
-            '@type': self.message_type,
-            '@fields': {
-                'levelname': record.levelname,
-                'logger': record.name,
-            },
-            '@tracectx.transactionid': str(txnId)
-        }
-
-        # Add extra fields
-        message['@fields'].update(self.get_extra_fields(record))
-
-        # If exception, add debug info
-        if record.exc_info:
-            message['@fields'].update(self.get_debug_fields(record))
-
-        return self.serialize(message)
-
-
-class LogstashFormatterVersion1(LogstashFormatterBase):
-
     def format(self, record):
         txnId = getattr(threadLocal, 'txnId', None)
         if(txnId is None):

--- a/ansible-adaptor/swagger_server/controllers/lifecycle_controller_controller.py
+++ b/ansible-adaptor/swagger_server/controllers/lifecycle_controller_controller.py
@@ -6,7 +6,6 @@ from datetime import date, datetime
 from typing import List, Dict
 from six import iteritems
 from ..util import deserialize_date, deserialize_datetime
-from flask import request
 
 from .ans_requests import RequestHandler
 from flask import abort

--- a/ansible-adaptor/swagger_server/controllers/lifecycle_controller_controller.py
+++ b/ansible-adaptor/swagger_server/controllers/lifecycle_controller_controller.py
@@ -6,14 +6,13 @@ from datetime import date, datetime
 from typing import List, Dict
 from six import iteritems
 from ..util import deserialize_date, deserialize_datetime
-
+from flask import request
 
 from .ans_requests import RequestHandler
 from flask import abort
 from flask import current_app as app
 import json
 import uuid
-
 
 def lifecycle_transitions_id_status_get(id):
     """
@@ -55,6 +54,7 @@ def lifecycle_transitions_post(transitionRequest=None):
     """
     if connexion.request.is_json:
         transitionRequest = TransitionRequest.from_dict(connexion.request.get_json())
+
     # app.logger.debug('transition request received: ' + transitionRequest)
     # create the request
     app.logger.info('working on transition request ')

--- a/ansible-adaptor/swagger_server/util.py
+++ b/ansible-adaptor/swagger_server/util.py
@@ -1,4 +1,8 @@
-from typing import GenericMeta
+try:
+    from typing import GenericMeta  # python 3.6
+except ImportError:
+    # in 3.7, genericmeta doesn't exist but we don't need it
+    class GenericMeta(type): pass
 from datetime import datetime, date
 from six import integer_types, iteritems, text_type
 

--- a/helm/osslm-ansible-resource-manager/Chart.yaml
+++ b/helm/osslm-ansible-resource-manager/Chart.yaml
@@ -1,0 +1,16 @@
+name: osslm-ansible-resource-manager
+version: 1.2.1
+appVersion: 1.2.1
+apiVersion: v1
+description: A Helm chart for the osslm-ansible-resource-manager
+# maintainers:
+#- name: 
+#  email: 
+keywords:
+- OSS
+- LM
+- OSSLM
+- Resource Manager
+- Ansible
+- IBM
+engine: gotpl

--- a/helm/osslm-ansible-resource-manager/README.md
+++ b/helm/osslm-ansible-resource-manager/README.md
@@ -1,0 +1,122 @@
+# Deploying Ansible-RM #
+
+These instructions detail how to deploy: 
+
+* Ansible RM
+* A single node Cassandra 
+
+It is expected that the user already has a Kubernetes installation, with the Lifecycle Manager already deployed. 
+
+It is recommended that you install the Ansible RM into the same Kubernetes namespace as the Lifecycle Manager.
+
+## Install dependencies ##
+
+Ensure you have the incubator repo:
+```
+helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
+```
+
+Download dependencies to "charts" directory:
+
+```
+helm dependency update osslm-ansible-resource-manager
+```
+
+Create Persistent Volume directories (if leaving createVolumes as true in helm chart values). Ensure current user owns the directories and give write access.
+
+```
+sudo mkdir -p /var/lib/osslm/
+sudo chown dvs:dvs /var/lib/osslm/
+mkdir /var/lib/osslm/vol-1
+mkdir /var/lib/osslm/vol-2
+mkdir /var/lib/osslm/vol-3
+chmod 777 /var/lib/osslm/*
+```
+
+NOTE: You can skip the need for persistent volumes by settings cassandra.persistence, kafka.persistence and kafka.zookeeper.persistence to false in the helm chart values.
+
+## Install Ansible RM ##
+
+Install Helm Chart
+
+```
+helm install osslm-ansible-resource-manager --name osslm-ansible-rm 
+```
+
+## Uninstall ##
+
+Uninstall Helm chart
+
+```
+helm delete osslm-ansible-rm --purge
+```
+
+Manually remove PV and PVs
+
+```
+kubectl delete pv -l createdBy=osslm-ansible-rm
+kubectl delete pvc -l release=osslm-ansible-rm 
+```
+
+Remove PV directories
+
+```
+sudo rm -rf /var/lib/osslm/vol-*
+```
+
+### Configuring connections to Cassandra/Kafka ###
+By default the container relies on Kubernetes to find a service named "kafka" for Kafka and "alm-ansible-rm-db" for Cassandra. By default this helm chart will create a Cassandra deplyoment and service this name.
+
+The helm chart may also create a Kafka deployment, however by default this is disabled. Instead the chart expects there is an existing Kafka deployed as part of LM, called foundation-kafka, so creates only a service for Kafka which selects the existing pods. 
+
+Alternatively you may use hosts to direct "kafka" and "alm-ansible-rm-db" to a fixed IP address.
+
+Create values file
+
+```
+touch ansible-rm-values.yaml
+vi ansible-rm-values.yaml
+```
+
+Add the following content
+
+```
+app:
+  config:
+    kafka:
+      hostEnabled: true
+      host: <some ip address>
+    cassandra:
+      hostEnabled: true
+      host: <some ip address>
+```
+
+### Configure Docker Image ###
+
+By default the Helm chart looks for a Docker image called osslm-ansible-rm:1.2 locally. If different then update image and version as shown below:
+
+Add to ansible-rm-values.yaml
+
+```
+docker:
+  image: different-name-for-osslm-ansible-rm
+  version: 1.2
+  imagePullPolicy: IfNotPresent
+```
+
+### Uninstall ###
+
+Uninstall Helm chart
+
+```
+helm delete osslm-ansible-rm --purge
+```
+
+## Accessing the Ansible-RM ##
+
+The Ansible-RM can be accessed in the Kubernetes network via **osslm-ansible-rm:8080** (only pods in the same namespace can access it this way).
+
+The Ansible-RM can be accessed externally via **<kubernetes-ip>:31080** where "kubernetes-ip" is the IP address of one of your Kubernetes nodes.
+
+Swagger-UI:
+http://<kubernetes-ip>:31080/api/v1.0/resource-manager/ui/

--- a/helm/osslm-ansible-resource-manager/README.md
+++ b/helm/osslm-ansible-resource-manager/README.md
@@ -41,7 +41,7 @@ NOTE: You can skip the need for persistent volumes by settings cassandra.persist
 Install Helm Chart
 
 ```
-helm install osslm-ansible-resource-manager-1.2.1.tgz --name osslm-ansible-rm --namespace default --debug
+helm install osslm-ansible-resource-manager-1.2.1.tgz --name osslm-ansible-rm --namespace default --values osslm-ansible-rm.values.yaml --debug
 #helm install osslm-ansible-resource-manager --name osslm-ansible-rm 
 ```
 

--- a/helm/osslm-ansible-resource-manager/README.md
+++ b/helm/osslm-ansible-resource-manager/README.md
@@ -30,6 +30,7 @@ sudo chown dvs:dvs /var/lib/osslm/
 mkdir /var/lib/osslm/vol-1
 mkdir /var/lib/osslm/vol-2
 mkdir /var/lib/osslm/vol-3
+mkdir /var/lib/osslm/vol-4
 chmod 777 /var/lib/osslm/*
 ```
 
@@ -40,7 +41,8 @@ NOTE: You can skip the need for persistent volumes by settings cassandra.persist
 Install Helm Chart
 
 ```
-helm install osslm-ansible-resource-manager --name osslm-ansible-rm 
+helm install osslm-ansible-resource-manager-1.2.1.tgz --name osslm-ansible-rm --namespace default --debug
+#helm install osslm-ansible-resource-manager --name osslm-ansible-rm 
 ```
 
 ## Uninstall ##

--- a/helm/osslm-ansible-resource-manager/requirements.lock
+++ b/helm/osslm-ansible-resource-manager/requirements.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: cassandra
+  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+  version: 0.4.1
+- name: kafka
+  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+  version: 0.8.5
+digest: sha256:ea9468f1bc5f2815e2706308f294d0640017b8cdbed3c8cc91cea7733ac68d77
+generated: 2018-11-15T16:40:54.789744Z

--- a/helm/osslm-ansible-resource-manager/requirements.yaml
+++ b/helm/osslm-ansible-resource-manager/requirements.yaml
@@ -1,0 +1,9 @@
+dependencies:
+  - name: cassandra
+    version: 0.4.1
+    repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+    condition: cassandra.enabled
+  - name: kafka
+    version: 0.8.5
+    repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+    condition: kafka.enabled

--- a/helm/osslm-ansible-resource-manager/templates/configmap.yaml
+++ b/helm/osslm-ansible-resource-manager/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: osslm-ansible-rm
+data:
+{{- if .Values.app.config.env }}
+{{ toYaml .Values.app.config.env | indent 2 }}
+{{- end }}
+  "LOG_LEVEL": {{ .Values.app.config.log.level }}
+  "LOG_FOLDER": {{ .Values.app.config.log.dir }}
+  "OS_CLIENT_CONFIG_FILE": {{ .Values.app.config.clientConfigFile }}

--- a/helm/osslm-ansible-resource-manager/templates/deployment.yaml
+++ b/helm/osslm-ansible-resource-manager/templates/deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: osslm-ansible-rm
+spec:
+  replicas: {{ .Values.app.replicas }}
+  template:
+    metadata:
+      labels:
+        app: osslm-ansible-rm
+    spec:
+      hostAliases:
+      {{- if .Values.app.config.kafka.hostEnabled }}
+        - ip: {{ .Values.app.config.kafka.host }}
+          hostnames:
+          - "kafka"
+      {{- end }}
+      {{- if .Values.app.config.cassandra.hostEnabled }}
+        - ip: {{ .Values.app.config.cassandra.host }}
+          hostnames:
+          - "alm-ansible-rm-db"
+      {{- end }}
+      containers:
+        - name: osslm-ansible-rm
+          image: {{ .Values.docker.image }}:{{ .Values.docker.version }}
+          imagePullPolicy: {{ .Values.docker.imagePullPolicy }}
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          envFrom:
+          - configMapRef:
+              name: osslm-ansible-rm

--- a/helm/osslm-ansible-resource-manager/templates/deployment.yaml
+++ b/helm/osslm-ansible-resource-manager/templates/deployment.yaml
@@ -30,3 +30,10 @@ spec:
           envFrom:
           - configMapRef:
               name: osslm-ansible-rm
+          volumeMounts:
+              - mountPath: /var/alm_ansible_rm
+                name: osslm-ansible-rm
+      volumes:
+      - name: osslm-ansible-rm
+        persistentVolumeClaim:
+          claimName: osslm-ansible-rm-vol4

--- a/helm/osslm-ansible-resource-manager/templates/lm-cassandra-service.yaml
+++ b/helm/osslm-ansible-resource-manager/templates/lm-cassandra-service.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.app.config.cassandra.useExisting }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: alm-ansible-rm-db
+spec:
+  ports:
+  - name: intra
+    port: 7000
+    targetPort: 7000
+  - name: tls
+    port: 7001
+    targetPort: 7001
+  - name: jmx
+    port: 7199
+    targetPort: 7199
+  - name: cql
+    port: 9042
+    targetPort: 9042
+  - name: thrift
+    port: 9160
+    targetPort: 9160
+  selector:
+{{ toYaml .Values.app.config.cassandra.existingSelectors | indent 4 }}
+{{- end }}

--- a/helm/osslm-ansible-resource-manager/templates/lm-kafka-service.yaml
+++ b/helm/osslm-ansible-resource-manager/templates/lm-kafka-service.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.app.config.kafka.useExisting }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+spec:
+  ports:
+  - name: broker
+    port: 9092
+    targetPort: kafka
+  selector:
+{{ toYaml .Values.app.config.kafka.existingSelectors | indent 4 }}
+{{- end }}

--- a/helm/osslm-ansible-resource-manager/templates/pv-1.yaml
+++ b/helm/osslm-ansible-resource-manager/templates/pv-1.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.createVolumes }}
+{{- if .Values.persistence.enabled }}
 kind: PersistentVolume
 apiVersion: v1
 metadata:
-  name: local-vol1
+  name: osslm-ansible-rm-vol1
   labels:
     type: local
     createdBy: osslm-ansible-rm
@@ -14,5 +14,5 @@ spec:
     - ReadWriteOnce
   hostPath:
     type: Directory
-    path: /var/lib/osslm/vol-1
+    path: {{ .Values.persistence.hostPath }}/vol-1
 {{ end }}

--- a/helm/osslm-ansible-resource-manager/templates/pv-1.yaml
+++ b/helm/osslm-ansible-resource-manager/templates/pv-1.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.createVolumes }}
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: local-vol1
+  labels:
+    type: local
+    createdBy: osslm-ansible-rm
+spec:
+  storageClassName: manual
+  capacity:
+    storage: {{ .Values.cassandra.persistence.size }}
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    type: Directory
+    path: /var/lib/osslm/vol-1
+{{ end }}

--- a/helm/osslm-ansible-resource-manager/templates/pv-2.yaml
+++ b/helm/osslm-ansible-resource-manager/templates/pv-2.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.createVolumes }}
+{{- if .Values.persistence.enabled }}
 kind: PersistentVolume
 apiVersion: v1
 metadata:
-  name: local-vol2
+  name: osslm-ansible-rm-vol2
   labels:
     type: local
     createdBy: osslm-ansible-rm
@@ -14,5 +14,5 @@ spec:
     - ReadWriteOnce
   hostPath:
     type: Directory
-    path: /var/lib/osslm/vol-2
+    path: {{ .Values.persistence.hostPath }}/vol-2
 {{ end }}

--- a/helm/osslm-ansible-resource-manager/templates/pv-2.yaml
+++ b/helm/osslm-ansible-resource-manager/templates/pv-2.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.createVolumes }}
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: local-vol2
+  labels:
+    type: local
+    createdBy: osslm-ansible-rm
+spec:
+  storageClassName: manual
+  capacity:
+    storage: {{ .Values.kafka.persistence.size }}
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    type: Directory
+    path: /var/lib/osslm/vol-2
+{{ end }}

--- a/helm/osslm-ansible-resource-manager/templates/pv-3.yaml
+++ b/helm/osslm-ansible-resource-manager/templates/pv-3.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.createVolumes }}
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: local-vol3
+  labels:
+    type: local
+    createdBy: osslm-ansible-rm
+spec:
+  storageClassName: manual
+  capacity:
+    storage: {{ .Values.kafka.zookeeper.persistence.size }}
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    type: Directory
+    path: /var/lib/osslm/vol-3
+{{ end }}

--- a/helm/osslm-ansible-resource-manager/templates/pv-3.yaml
+++ b/helm/osslm-ansible-resource-manager/templates/pv-3.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.createVolumes }}
+{{- if .Values.persistence.enabled }}
 kind: PersistentVolume
 apiVersion: v1
 metadata:
-  name: local-vol3
+  name: osslm-ansible-rm-vol3
   labels:
     type: local
     createdBy: osslm-ansible-rm
@@ -14,5 +14,5 @@ spec:
     - ReadWriteOnce
   hostPath:
     type: Directory
-    path: /var/lib/osslm/vol-3
+    path: {{ .Values.persistence.hostPath }}/vol-3
 {{ end }}

--- a/helm/osslm-ansible-resource-manager/templates/pv-4.yaml
+++ b/helm/osslm-ansible-resource-manager/templates/pv-4.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.persistence.enabled }}
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: osslm-ansible-rm-vol4
+  labels:
+    type: local
+    createdBy: osslm-ansible-rm
+spec:
+  storageClassName: {{ .Values.persistence.storageClass }}
+  capacity:
+    storage: {{ .Values.persistence.size }}
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    type: Directory
+    path: {{ .Values.persistence.hostPath }}/vol-4
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: osslm-ansible-rm-vol4
+  labels:
+    type: local
+    createdBy: osslm-ansible-rm
+spec:
+  storageClassName: {{ .Values.persistence.storageClass }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  accessModes:
+    - ReadWriteOnce
+  volumeName: osslm-ansible-rm-vol4
+{{ end }}

--- a/helm/osslm-ansible-resource-manager/templates/service.yaml
+++ b/helm/osslm-ansible-resource-manager/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: osslm-ansible-rm
+  labels:
+    app: osslm-ansible-rm
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: 8080
+    targetPort: 8080
+{{- if eq .Values.service.type "NodePort" }}
+    nodePort: {{ .Values.service.nodePort }}
+{{- end }}
+    protocol: TCP
+    name: http
+  selector:
+    app: osslm-ansible-rm

--- a/helm/osslm-ansible-resource-manager/values.yaml
+++ b/helm/osslm-ansible-resource-manager/values.yaml
@@ -55,6 +55,9 @@ app:
     env:
 #      cassandra_ttl: 
       cassandra_uri: foundation-cassandra
+      # to support indexing of logs in Elasticsearch using Filebeat, we use logstash format. This allows
+      # us to bundle the log message and other metadata in a json log message and let Fielbeat extract them
+      # as top level fields in the Elasticsearch index.
       LOG_TYPE: logstash
 
 persistence:

--- a/helm/osslm-ansible-resource-manager/values.yaml
+++ b/helm/osslm-ansible-resource-manager/values.yaml
@@ -1,0 +1,123 @@
+## Docker Image for the osslm-ansible-rm application
+docker:
+  ## Make this the full path, including registry host and port if using one
+  image: osslm-ansible-rm
+  version: 1.2
+  imagePullPolicy: IfNotPresent
+
+
+## Configuration for the application deployment
+app:
+  ## Number of pods to deploy 
+  replicas: 1
+  ## osslm-ansible-rm specific configuration
+  config:
+    kafka:
+      ## Assumes the responseKafkaConnectionUrl value provided as part of the clientConfigFile is still kafka:9092 - which means we must have a "kafka" host available
+      ## There 2 options for this
+
+      ## Option 1 (enabled by default)
+      ## Access an existing Kafka installed by the Lifecycle Manager in the same Kubernetes namespace
+      ## This creates an additional service that forwards traffic to the existing Kafka pods
+      ## Expects a Kafka installed using helm-foundation provided with the Lifecycle Manager
+      useExisting: true
+      existingSelectors:
+        app: kafka
+        release: foundation
+
+      ## Option 2 
+      ## Fixed IP. This is added as a host entry to the container.
+      hostEnabled: false
+      host: 
+
+      ## Option 3
+      ## Install kafka as part of this helm chart (see kafka.enabled) then disable useExisting and hostEnabled
+      
+    cassandra:
+      ## Option 1 (enabled by default)
+      ## Access an existing Cassandra installed by the Lifecycle Manager in the same Kubernetes namespace
+      ## This creates an additional service that forwards traffic to the existing Cassandra pods
+      ## Expects a Cassandra installed using helm-foundation provided with the Lifecycle Manager
+      useExisting: true
+      existingSelectors:
+        app: cassandra
+        release: foundation
+
+      ## Alternative IP for connecting to cassandra
+      hostEnabled: false
+      host: 
+    ## Configure logging 
+    log:
+      level: DEBUG
+      dir: /var/alm_ansible_rm/logs
+    ## Sets the OS_CLIENT_CONFIG_FILE environment variable
+    clientConfigFile: /var/alm_ansible_rm/clouds/clouds.yaml
+    ## Pass additional environment variables to the application containers
+    # env:
+
+service:
+  # Using NodePort allows access to the IPs through http://k8s-host:nodePort/
+  type: NodePort
+  nodePort: 31080
+
+## Optionally create the PVs needed. Only creates 3 volumes, so there must only be 1 replica of Cassandra, Kafka and Zookeeper
+createVolumes: false
+
+cassandra:
+  enabled: false
+  ## Required as the ansible-rm application always connects to Cassandra on this hostname
+  fullnameOverride: alm-ansible-rm-db
+  ## Requires setting up the LocalStorage class and creating a Persistent Volume
+  persistence:
+    enabled: true
+    storageClass: "manual"
+    size: "1Gi"
+  config:
+    cluster_name: alm-ansible-rm-cluster
+    cluster_size: 1
+    seed_size: 1
+    max_heap_size: 1024M
+    heap_new_size: 512M
+  resources:
+    requests:
+      cpu: 500m
+      memory: "1Gi"
+    limits:
+      cpu: 2
+      memory: "4Gi"
+
+kafka:
+  enabled: false
+  ## Required as the ansible-rm application connects to Kafka on this hostname (from the default config file: OS_CLIENT_CONFIG_FILE=/var/alm_ansible_rm/clouds/clouds.yaml)
+  fullnameOverride: kafka
+  replicas: 1
+  storageClass: "manual"
+  ## Requires setting up the LocalStorage class and creating a Persistent Volume
+  persistence:
+    enabled: true
+    size: "1Gi"
+    storageClass: "manual"
+
+  ## The following allows Kafka to be accessed outside of K8s at kafka.osslm:31090, if you add kafka.osslm to your hosts file with the k8s IP
+  external: 
+    enabled: true
+    domain: osslm
+  rbac:
+    enabled: true  
+  configurationOverrides:
+    offsets.topic.replication.factor: 1
+    advertised.listeners: |-
+      EXTERNAL://kafka.osslm:$((31090 + ${KAFKA_BROKER_ID}))
+    listener.security.protocol.map: |-
+      PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+
+  topics:
+  - name: ansible-rm
+    partitions: 1
+    replicationFactor: 1
+  zookeeper:
+    replicaCount: 1
+    persistence:
+      enabled: true
+      storageClass: "manual"
+      size: "1Gi"

--- a/helm/osslm-ansible-resource-manager/values.yaml
+++ b/helm/osslm-ansible-resource-manager/values.yaml
@@ -2,9 +2,8 @@
 docker:
   ## Make this the full path, including registry host and port if using one
   image: osslm-ansible-rm
-  version: 1.2
+  version: 1.2.1
   imagePullPolicy: IfNotPresent
-
 
 ## Configuration for the application deployment
 app:
@@ -53,15 +52,22 @@ app:
     ## Sets the OS_CLIENT_CONFIG_FILE environment variable
     clientConfigFile: /var/alm_ansible_rm/clouds/clouds.yaml
     ## Pass additional environment variables to the application containers
-    # env:
+    env:
+#      cassandra_ttl: 
+      cassandra_uri: foundation-cassandra
+      LOG_TYPE: logstash
+
+persistence:
+  size: "1Gi"
+  ## If enabled, will create the PVs needed. Only creates 4 volumes, so there must only be 1 replica of Cassandra, Kafka and Zookeeper
+  enabled: false
+  storageClass: "manual"
+  hostPath: /var/lib/osslm
 
 service:
   # Using NodePort allows access to the IPs through http://k8s-host:nodePort/
   type: NodePort
   nodePort: 31080
-
-## Optionally create the PVs needed. Only creates 3 volumes, so there must only be 1 replica of Cassandra, Kafka and Zookeeper
-createVolumes: false
 
 cassandra:
   enabled: false


### PR DESCRIPTION
I've added a Helm chart to support installation in to Kubernetes and some logging enhancements. In particular:

1) Support for "logstash" logging messages, to allow Filebeat to parse JSON logs consisting of a message and other supporting metadata (like LM "") and index in to Elasticsearch. Turned on by default in Helm charts. Otherwise, default is as before i.e. basic text log messages.
2) The ability to configure the Cassandra uri
3) Incremented the version number to 1.2.1